### PR TITLE
Bugfix 'AccessDeniedException:/usr/share/elasticsearch/data/nodes'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.7.0
     volumes:
-      - ./elastic:/usr/share/elasticsearch/data   
+      - ./elastic:/usr/share/elasticsearch/data:rw
     container_name: elasticsearch
     ports:
       - "9200:9200"


### PR DESCRIPTION
The fix is ​​in Ubuntu and docker compose, when the container was started it crashed due to not having write privileges on folder ':/usr/share/elasticsearch/data/nodes'